### PR TITLE
zh-CN: Fix normalize function

### DIFF
--- a/site/zh-cn/tutorials/images/segmentation.ipynb
+++ b/site/zh-cn/tutorials/images/segmentation.ipynb
@@ -218,7 +218,7 @@
       },
       "source": [
         "def normalize(input_image, input_mask):\n",
-        "  input_image = tf.cast(input_image, tf.float32)/128.0 - 1\n",
+        "  input_image = tf.cast(input_image, tf.float32)/255.0\n",
         "  input_mask -= 1\n",
         "  return input_image, input_mask"
       ],


### PR DESCRIPTION
From
```python
input_image = tf.cast(input_image, tf.float32)/128.0 - 1
```
to
```python
input_image = tf.cast(input_image, tf.float32)/255.0
```
, because image is normalized to [0,1]